### PR TITLE
Add backgroundImage property to TapTargetStyle for custom designs

### DIFF
--- a/tap-target-compose/src/main/java/com/psoffritti/taptargetcompose/Rendering.kt
+++ b/tap-target-compose/src/main/java/com/psoffritti/taptargetcompose/Rendering.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInWindow
@@ -278,12 +280,45 @@ private fun TapTargetRenderer(
     }
 
     // Draw outer circle
-    drawCircle(
-      center = getTargetCenter(),
-      radius = outerCircleRadius * outerCircleScaleProvider(),
-      color = tapTarget.style.backgroundColor,
-      alpha = tapTarget.style.backgroundAlpha
-    )
+    val scaledRadius = outerCircleRadius * outerCircleScaleProvider()
+    val center = getTargetCenter()
+
+    if (tapTarget.style.backgroundImage != null) {
+      // Draw with background image
+      val circlePath = Path().apply {
+        addOval(
+          Rect(
+            center = center,
+            radius = scaledRadius
+          )
+        )
+      }
+      clipPath(circlePath) {
+        val imageSize = Size(scaledRadius * 2, scaledRadius * 2)
+        val topLeft = Offset(
+          center.x - scaledRadius,
+          center.y - scaledRadius
+        )
+        // Translate to position and draw the image
+        translate(left = topLeft.x, top = topLeft.y) {
+          with(tapTarget.style.backgroundImage) {
+            draw(
+              size = imageSize,
+              alpha = tapTarget.style.backgroundAlpha,
+              colorFilter = null
+            )
+          }
+        }
+      }
+    } else {
+      // Draw with solid color
+      drawCircle(
+        center = center,
+        radius = scaledRadius,
+        color = tapTarget.style.backgroundColor,
+        alpha = tapTarget.style.backgroundAlpha
+      )
+    }
 
     // Draw highlight circle
     drawCircle(

--- a/tap-target-compose/src/main/java/com/psoffritti/taptargetcompose/TapTarget.kt
+++ b/tap-target-compose/src/main/java/com/psoffritti/taptargetcompose/TapTarget.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.TextStyle
@@ -190,12 +191,15 @@ data class TextDefinition(
  * @param backgroundColor The background color of the main circle.
  * @param backgroundAlpha The alpha of the main circle.
  * @param tapTargetHighlightColor The color of the highlight circle.
+ * @param backgroundImage Optional image to use as the background instead of a solid color.
+ * When provided, this will be drawn instead of the backgroundColor.
  */
 data class TapTargetStyle(
   val backgroundColor: Color = Color.Blue,
   @FloatRange(from = 0.0, to = 1.0)
   val backgroundAlpha: Float = 1f,
   val tapTargetHighlightColor: Color = Color.White,
+  val backgroundImage: Painter? = null,
 ) {
   companion object {
     val Default = TapTargetStyle()


### PR DESCRIPTION
- Added optional backgroundImage (Painter?) property to TapTargetStyle
- Modified rendering logic to support image backgrounds
- When backgroundImage is provided, it's drawn in a circular clip instead of solid color
- Maintains backward compatibility with existing backgroundColor property
- Allows for more flexible and custom tap target designs