### PR TITLE
Key tap target animations and gestures on precedence

### DIFF
--- a/tap-target-compose/src/main/java/com/psoffritti/taptargetcompose/Rendering.kt
+++ b/tap-target-compose/src/main/java/com/psoffritti/taptargetcompose/Rendering.kt
@@ -149,7 +149,7 @@ internal fun TapTarget(tapTarget: TapTarget, onComplete: () -> Unit) {
 
   if (animateIn) {
     AnimateIn(
-      key1 = tapTarget,
+      key1 = tapTarget.precedence,
       outerCircleAnimatable = outerCircleScaleAnimatable,
       highlightCircleAnimatable = highlightCircleScaleAnimatable,
       tapTargetCircleAnimatable = tapTargetCircleScaleAnimatable,
@@ -158,7 +158,7 @@ internal fun TapTarget(tapTarget: TapTarget, onComplete: () -> Unit) {
   }
   else {
     AnimateOut(
-      key1 = tapTarget,
+      key1 = tapTarget.precedence,
       outerCircleAnimatable = outerCircleScaleAnimatable,
       highlightCircleAnimatable = highlightCircleScaleAnimatable,
       textAlphaAnimatable= textAlphaScaleAnimatable
@@ -264,7 +264,7 @@ private fun TapTargetRenderer(
   Canvas(
     modifier = Modifier
       .fillMaxSize()
-      .pointerInput(tapTarget) {
+      .pointerInput(tapTarget.precedence) {
         detectTapGestures { tapOffset ->
           when {
             tapOffset.isOutsideCircle(getTargetCenter(), outerCircleRadius) -> {


### PR DESCRIPTION
## Problem

`AnimateIn`, `AnimateOut`, and the gesture detector's `pointerInput` are keyed on the whole `TapTarget` instance. Because the key uses instance identity, the animations and the tap gesture handler restart whenever a new—but value-equal—`TapTarget` object is created across recompositions. This causes the highlight animation to visibly re-trigger and gestures to be re-registered unnecessarily.

## Fix

Key on the stable `tapTarget.precedence` (an `Int` that uniquely identifies the target within a sequence) instead of the instance. The keyed effects now only restart when the target actually changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)